### PR TITLE
Reintroduce development docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3-alpine AS builder
+FROM python:3.8.3-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
@@ -6,14 +6,4 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/src/app
 COPY . .
 
-RUN apk update && apk add --no-cache python3-dev
-RUN python3 ./setup.py bdist_wheel -d build
-
-
-# Production image
-FROM python:3.8.3-alpine
-COPY --from=builder /usr/src/app/build/httpcheck-*-py3-none-any.whl /usr/local/src/
-
-RUN apk update && apk add --no-cache postgresql-dev gcc python3-dev musl-dev
-RUN python3 -m pip install /usr/local/src/httpcheck-1.0-py3-none-any.whl[test]
-RUN apk del gcc python3-dev musl-dev
+RUN apk add --no-cache postgresql-dev gcc python3-dev musl-dev && python3 -m pip install -e .[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   dbimport:
     build: .
+    image: httpcheck_dev
     restart: unless-stopped
     command: /usr/local/bin/httpcheck-dbimport
     working_dir: /usr/src/app
@@ -13,6 +14,7 @@ services:
       - .:/usr/src/app
   httpcheck:
     build: .
+    image: httpcheck_dev
     restart: unless-stopped
     working_dir: /usr/src/app
     command: /usr/local/bin/httpcheck --websites ./websites.json

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8.3-alpine AS builder
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /usr/src/app
+COPY . .
+
+RUN apk update && apk add --no-cache python3-dev
+RUN python3 ./setup.py bdist_wheel -d build
+
+
+# Production image
+FROM python:3.8.3-alpine
+COPY --from=builder /usr/src/app/build/httpcheck-*-py3-none-any.whl /usr/local/src/
+
+RUN apk update && apk add --no-cache postgresql-dev gcc python3-dev musl-dev
+RUN python3 -m pip install /usr/local/src/httpcheck-1.0-py3-none-any.whl[test]
+RUN apk del gcc python3-dev musl-dev


### PR DESCRIPTION
Developing is too arduous if you can't run the current code in docker
without a rebuild. The production Dockerfile is kept separately in case
it is ever to be used.