### PR TITLE
Refactor: decouple scheduler from websitemonitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3-alpine AS builder
+FROM python:3.8.3-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
@@ -6,14 +6,4 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/src/app
 COPY . .
 
-RUN apk update && apk add --no-cache python3-dev
-RUN python3 ./setup.py bdist_wheel -d build
-
-
-# Production image
-FROM python:3.8.3-alpine
-COPY --from=builder /usr/src/app/build/httpcheck-*-py3-none-any.whl /usr/local/src/
-
-RUN apk update && apk add --no-cache postgresql-dev gcc python3-dev musl-dev
-RUN python3 -m pip install /usr/local/src/httpcheck-1.0-py3-none-any.whl[test]
-RUN apk del gcc python3-dev musl-dev
+RUN apk add --no-cache postgresql-dev gcc python3-dev musl-dev && python3 -m pip install -e .[test]

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Here is an example JSON file that can be used to setup two websites to be monito
 
 ```json
 {
-  "https://example.com/health1": { "frequency_online": 300  },
-  "https://example.com/health2": { "frequency_online": 120, "frequency_offline": 30 }
+  "https://example.com/health1": { "frequency": 300 },
+  "https://example.com/health2": { "frequency": 120 }
 }
 ```
 
@@ -112,8 +112,8 @@ If you would like to reserve the ability to seamlessly change the URL, you can u
 
 ```json
 {
-  "one": {"url": "https://example.com/health1", "frequency_online": 300  },
-  "two": {"url": "https://example.com/health2", "frequency_online": 120, "frequency_offline": 30 }
+  "one": {"url": "https://example.com/health1", "frequency": 300 },
+  "two": {"url": "https://example.com/health2", "frequency": 120 }
 }
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   dbimport:
     build: .
+    image: httpcheck_dev
     restart: unless-stopped
     command: /usr/local/bin/httpcheck-dbimport
     working_dir: /usr/src/app
@@ -13,6 +14,7 @@ services:
       - .:/usr/src/app
   httpcheck:
     build: .
+    image: httpcheck_dev
     restart: unless-stopped
     working_dir: /usr/src/app
     command: /usr/local/bin/httpcheck --websites ./websites.json

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8.3-alpine AS builder
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /usr/src/app
+COPY . .
+
+RUN apk update && apk add --no-cache python3-dev
+RUN python3 ./setup.py bdist_wheel -d build
+
+
+# Production image
+FROM python:3.8.3-alpine
+COPY --from=builder /usr/src/app/build/httpcheck-*-py3-none-any.whl /usr/local/src/
+
+RUN apk update && apk add --no-cache postgresql-dev gcc python3-dev musl-dev
+RUN python3 -m pip install /usr/local/src/httpcheck-1.0-py3-none-any.whl[test]
+RUN apk del gcc python3-dev musl-dev

--- a/src/httpcheck/cli.py
+++ b/src/httpcheck/cli.py
@@ -24,8 +24,7 @@ def httpcheck_cli():
         "timeout": "Number of seconds to wait for the HTTP response",
         "retries": "Number of immediate retries when HTTP connection fails",
         "regex": "A regular expression to search for in the response",
-        "frequency_online": "Seconds to wait before re-checking an online website",
-        "frequency_offline": "Seconds to wait before re-checking an offline website",
+        "frequency": "Seconds to wait before re-checking website",
         "kafka_broker": "Name and port for the Kafka broker to send results to",
         "kafka_topic": "Name of the topic in Kafka",
         "kafka_ssl_cafile": "Filename for a CA file (Kafka SSL auth)",
@@ -42,8 +41,7 @@ def httpcheck_cli():
 @click.option("--timeout", default=30)
 @click.option("--retries", default=1)
 @click.option("--regex",)
-@click.option("--frequency-online", default=300)
-@click.option("--frequency-offline", default=60)
+@click.option("--frequency", default=300)
 @click.option("--kafka-broker",)
 @click.option("--kafka-topic")
 @click.option("--kafka-ssl-cafile", type=FilePath)
@@ -58,8 +56,7 @@ def httpcheck_main(
     timeout,
     retries,
     regex,
-    frequency_online,
-    frequency_offline,
+    frequency,
     websites,
     kafka_broker,
     kafka_topic,
@@ -79,8 +76,7 @@ def httpcheck_main(
             timeout_read=timeout,
             retries=retries,
             regex=regex,
-            frequency_online=frequency_online,
-            frequency_offline=frequency_offline,
+            frequency=frequency,
         )
         monitor_configs[url] = monitor_config
 

--- a/src/httpcheck/websitemonitor.py
+++ b/src/httpcheck/websitemonitor.py
@@ -38,18 +38,18 @@ class WebsiteMonitor:
         return self.config.frequency
 
     async def attempt_and_publish(self, publisher):
-        check = await self.make_attempt()
-        data = json.dumps(dataclasses.asdict(check))
+        check_results = await self.make_attempt()
+        data = json.dumps(dataclasses.asdict(check_results))
         publisher.publish(data)
 
     async def make_attempt(self):
-        check = WebsiteCheck(
+        check_results = WebsiteCheckResults(
             url=self.config.url,
             identifier=self.config.identifier,
             regex=self.config.regex,
         )
-        await check.run(self.make_http_request, self.config.retries)
-        return check
+        await check_results.run(self.make_http_request, self.config.retries)
+        return check_results
 
     async def make_http_request(self):
         _timeout = httpx.Timeout(
@@ -67,7 +67,7 @@ def now_isoformat():
 
 
 @dataclasses.dataclass
-class WebsiteCheck:
+class WebsiteCheckResults:
     """ Run and record the results for a single website check. """
 
     url: str

--- a/tests/system.py
+++ b/tests/system.py
@@ -29,13 +29,13 @@ def system_test():
         url = "http://example.com"
         url_offline = "https://expired.badssl.com/"
         offline_website_conf = {
-            url_offline: {"identifier": identifier2, "frequency_offline": 9}
+            url_offline: {"identifier": identifier2, "frequency": 9}
         }
         json.dump(offline_website_conf, websites_json)
         websites_json.flush()
 
         run(
-            f"httpcheck {url} --identifier={identifier1} --frequency-online=5"
+            f"httpcheck {url} --identifier={identifier1} --frequency=5"
             f" --websites={websites_json.name}",
             timeout=14,
         )
@@ -69,7 +69,9 @@ def validate_environment():
     missing_vars = ", ".join(e for e in required_env_vars if e not in os.environ)
     if missing_vars:
         click.secho(
-            "\nPlease provide Kafka and postgres configuration in a file called `.env`\n"
+            "\n"
+            "Please provide Kafka and postgres configuration in a file called `.env`\n"
+            ""
             f"Missing: {missing_vars}",
             err=True,
             fg="red",

--- a/tests/websites.json
+++ b/tests/websites.json
@@ -1,5 +1,5 @@
 {
-  "https://google.com/": { "frequency_online": 60  },
-  "http://willhardy.com.au": { "frequency_online": 50 },
-  "http://wajsdifoasdfjasdiofjillhardy.com.au": { "frequency_offline": 20, "retries": 3 }
+  "https://google.com/": { "frequency": 60  },
+  "http://willhardy.com.au": { "frequency": 50 },
+  "http://wajsdifoasdfjasdiofjillhardy.com.au": { "frequency": 20, "retries": 3 }
 }


### PR DESCRIPTION
The `frequency_online` and `frequency_offline` options are cute, maybe
slightly useful, but ultimately they dramatically change the
architecture by coupling the scheduler with the website monitor,
primarily because the result of the check determines the scheduling.

This complicates or prevents a number of things, such as adding a
queue between the scheduling and the execution (which would help
scale), and the benefit is too small to justify the complication.

This change also decouples the scheduler implementation from the system,
adding a facade and removing all scheduler interaction from the
`WebsiteMonitor` class.


(based on [branch:refactor-docker](/willhardy/httpcheck/tree/refactor-docker) until that is merged)